### PR TITLE
Redox: Use create() instead of open() when setting env variable

### DIFF
--- a/src/libstd/sys/redox/os.rs
+++ b/src/libstd/sys/redox/os.rs
@@ -179,7 +179,7 @@ pub fn getenv(key: &OsStr) -> io::Result<Option<OsString>> {
 
 pub fn setenv(key: &OsStr, value: &OsStr) -> io::Result<()> {
     if ! key.is_empty() {
-        let mut file = ::fs::File::open(&("env:".to_owned() + key.to_str().unwrap()))?;
+        let mut file = ::fs::File::create(&("env:".to_owned() + key.to_str().unwrap()))?;
         file.write_all(value.as_bytes())?;
         file.set_len(value.len() as u64)?;
     }


### PR DESCRIPTION
Needed for https://github.com/redox-os/kernel/pull/25.